### PR TITLE
Fix post-diffusion BFGS relaxation blowing up structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.claude/
 .pytest_cache
 .coverage
 .coverage.xml

--- a/src/agedi/diffusion/diffusion.py
+++ b/src/agedi/diffusion/diffusion.py
@@ -735,6 +735,11 @@ class Diffusion:
 
         # Optional post-diffusion relaxation
         if force_field_guidance > 0 and self.regressor_model is not None:
+            # Reset LBFGS memory: history from the noisy diffusion trajectory
+            # carries stale curvature information that corrupts relaxation steps.
+            if self.lbfgs_step_sizer is not None:
+                self.lbfgs_step_sizer.reset()
+
             if timings is None:
                 batch = self.regressor_model(batch)
             else:

--- a/src/agedi/diffusion/guidance.py
+++ b/src/agedi/diffusion/guidance.py
@@ -324,6 +324,7 @@ def post_diffusion_relaxation_step(
     regressor_model: "torch.nn.Module",
     lbfgs_step_sizer: Optional[BatchedLBFGSStepSizer],
     scale: float = 0.1,
+    max_step_size: float = 0.1,
 ) -> AtomsGraph:
     """Perform a pure force-based relaxation step after diffusion is complete.
 
@@ -365,7 +366,15 @@ def post_diffusion_relaxation_step(
 
     lbfgs_step = lbfgs_step_sizer.compute_step(positions, forces, batch_idx)
 
-    new_pos = batch.pos + scale * lbfgs_step
+    step = scale * lbfgs_step
+    step_magnitude = torch.norm(step, dim=1, keepdim=True)
+    too_large = step_magnitude > max_step_size
+    if torch.any(too_large):
+        scaling_factor = torch.ones_like(step_magnitude)
+        scaling_factor[too_large] = max_step_size / step_magnitude[too_large]
+        step = step * scaling_factor
+
+    new_pos = batch.pos + step
 
     if hasattr(batch, "confinement") and batch.confinement is not None:
         z_min = batch.confinement[:, 0].unsqueeze(1)  # [B, 1]


### PR DESCRIPTION
## Summary

- **Reset L-BFGS memory before post-diffusion relaxation**: The step sizer
  accumulated history throughout the entire noisy diffusion trajectory. When
  relaxation began, `prev_pos`/`prev_forces` from the noisy regime caused the
  curvature estimate (`y = prev_forces - forces`) to mix noisy and clean-structure
  forces, producing a corrupted inverse-Hessian and divergent position updates.

- **Add `max_step_size` clamping to `post_diffusion_relaxation_step`**: Unlike
  `force_field_guidance_step` which already clamped steps to 0.1 Å, the
  relaxation step had no bound — any large L-BFGS step was applied directly
  to positions.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup

## Checklist

- [ ] Tests added / updated for all new behaviour
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] All existing tests pass (`pytest`)
- [ ] Docstrings updated for new/changed public API
- [ ] No new `print()` calls in library code (use `warnings.warn` or Rich `Console`)

## Related issues

<!-- Closes #<issue number> -->
