### PR TITLE
Bypass cell-list for non-periodic neighbor lists (pbc=False)

### DIFF
--- a/src/agedi/data/atoms_graph.py
+++ b/src/agedi/data/atoms_graph.py
@@ -711,6 +711,47 @@ class AtomsGraph(Data):
         return True
 
     @staticmethod
+    def _make_graph_no_pbc(
+        positions: torch.Tensor,
+        cutoff: float,
+        dtype: Optional[torch.dtype] = None,
+        batch_idx: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Non-periodic neighbor list via direct pairwise distances (no cell needed)."""
+        output_dtype = dtype or positions.dtype
+        device = positions.device
+
+        if batch_idx is None:
+            diff = positions.unsqueeze(0) - positions.unsqueeze(1)
+            dist_sq = (diff ** 2).sum(-1)
+            mask = (dist_sq < cutoff ** 2) & (dist_sq > 0)
+            src, dst = torch.where(mask)
+            edge_index = torch.stack([src, dst], dim=0)
+            shift_vectors = torch.zeros(edge_index.shape[1], 3, dtype=output_dtype, device=device)
+            return edge_index, shift_vectors
+
+        num_graphs = int(batch_idx.max().item()) + 1 if positions.shape[0] > 0 else 0
+        edge_index_parts = []
+        total_edges = 0
+        for g in range(num_graphs):
+            atom_idx = torch.where(batch_idx == g)[0]
+            if atom_idx.numel() <= 1:
+                continue
+            local_ei, _ = AtomsGraph._make_graph_no_pbc(positions[atom_idx], cutoff, dtype=output_dtype)
+            edge_index_parts.append(atom_idx[local_ei])
+            total_edges += local_ei.shape[1]
+
+        if not edge_index_parts:
+            return (
+                torch.empty((2, 0), dtype=torch.long, device=device),
+                torch.zeros((0, 3), dtype=output_dtype, device=device),
+            )
+        return (
+            torch.cat(edge_index_parts, dim=1),
+            torch.zeros(total_edges, 3, dtype=output_dtype, device=device),
+        )
+
+    @staticmethod
     def _make_graph_matscipy(
         positions: torch.Tensor,
         cell: torch.Tensor,
@@ -723,18 +764,6 @@ class AtomsGraph(Data):
         if batch_idx is None:
             cell_np = cell.detach().cpu().numpy()
             pbc_np = pbc.detach().cpu().numpy()
-            # matscipy inverts the cell internally even when pbc=False; for
-            # non-periodic systems with no cell, build a tight bounding box so
-            # the cell-list grid stays small (a fixed 1000 Å dummy would create
-            # ~4 M empty grid cells and make the neighbour search very slow).
-            if not pbc_np.any() and not cell_np.any():
-                pos_np = positions.detach().cpu().numpy()
-                if len(pos_np) > 0:
-                    extent = pos_np.max(axis=0) - pos_np.min(axis=0) + 2 * cutoff
-                    extent = np.maximum(extent, cutoff)  # at least one cell wide
-                else:
-                    extent = np.full(3, cutoff, dtype=cell_np.dtype)
-                cell_np = np.diag(extent.astype(cell_np.dtype))
             i, j, shifts = matscipy_neighbour_list(
                 "ijS",
                 positions=positions.detach().cpu().numpy(),
@@ -874,7 +903,14 @@ class AtomsGraph(Data):
         with torch.no_grad():
             _pbc = pbc.view(-1, 3) if batch_idx is not None else pbc.view(3)
             _any_pbc = bool(_pbc.any())
-            if nvidia_neighbor_list is None or not _any_pbc:
+            if not _any_pbc:
+                return AtomsGraph._make_graph_no_pbc(
+                    positions,
+                    cutoff,
+                    dtype=dtype,
+                    batch_idx=batch_idx,
+                )
+            if nvidia_neighbor_list is None:
                 return AtomsGraph._make_graph_matscipy(
                     positions,
                     cell,

--- a/tests/data/test_atoms_graph.py
+++ b/tests/data/test_atoms_graph.py
@@ -275,4 +275,102 @@ def test_get_representation(graph: AtomsGraph) -> None:
     assert torch.allclose(scalar, rep2.scalar)
     assert torch.allclose(vector, rep2.vector)
 
-    
+
+# ---------------------------------------------------------------------------
+# Non-periodic neighbor list (_make_graph_no_pbc)
+# ---------------------------------------------------------------------------
+
+def test_make_graph_no_pbc_returns_correct_edges() -> None:
+    """_make_graph_no_pbc must find all pairs within cutoff, no self-loops."""
+    cutoff = 3.0
+    pos = torch.tensor([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [5.0, 0.0, 0.0]], dtype=torch.float32)
+    ei, sv = AtomsGraph._make_graph_no_pbc(pos, cutoff)
+
+    assert ei.shape[0] == 2
+    assert sv.shape == (ei.shape[1], 3)
+    assert (sv == 0).all(), "Shift vectors must be zero for non-periodic graphs"
+
+    # Atoms 0 and 1 are within cutoff; atom 2 is not.
+    pairs = set(map(tuple, ei.T.tolist()))
+    assert (0, 1) in pairs
+    assert (1, 0) in pairs
+    assert (0, 2) not in pairs
+    assert (2, 0) not in pairs
+    # No self-loops
+    assert all(s != d for s, d in pairs)
+
+
+def test_make_graph_no_pbc_all_pairs_within_cutoff() -> None:
+    """Edge distances must never exceed the cutoff."""
+    cutoff = 4.0
+    pos = torch.randn(10, 3, dtype=torch.float32) * 2
+    ei, _ = AtomsGraph._make_graph_no_pbc(pos, cutoff)
+    src, dst = ei
+    dists = (pos[dst] - pos[src]).norm(dim=-1)
+    assert (dists <= cutoff + 1e-5).all()
+
+
+def test_make_graph_no_pbc_matches_matscipy() -> None:
+    """_make_graph_no_pbc and _make_graph_matscipy must agree on a small molecule."""
+    from ase.build import molecule
+    cutoff = 5.0
+    atoms = molecule("H2O")
+    pos = torch.tensor(atoms.positions, dtype=torch.float32)
+    # Provide a cell large enough that pbc=False matscipy gives the same result.
+    cell = torch.eye(3) * 50.0
+    pbc = torch.tensor([False, False, False])
+
+    ei_nopbc, _ = AtomsGraph._make_graph_no_pbc(pos, cutoff)
+    ei_matscipy, _ = AtomsGraph._make_graph_matscipy(pos, cell, cutoff, pbc)
+
+    pairs_nopbc = set(map(tuple, ei_nopbc.T.tolist()))
+    pairs_matscipy = set(map(tuple, ei_matscipy.T.tolist()))
+    assert pairs_nopbc == pairs_matscipy
+
+
+def test_make_graph_no_pbc_batched() -> None:
+    """Batched _make_graph_no_pbc must not create cross-graph edges."""
+    cutoff = 3.0
+    pos = torch.tensor([
+        [0.0, 0.0, 0.0], [1.0, 0.0, 0.0],  # graph 0 — close pair
+        [0.0, 0.0, 0.0], [1.0, 0.0, 0.0],  # graph 1 — same positions, different graph
+    ], dtype=torch.float32)
+    batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32)
+
+    ei, sv = AtomsGraph._make_graph_no_pbc(pos, cutoff, batch_idx=batch_idx)
+
+    assert (sv == 0).all()
+    pairs = set(map(tuple, ei.T.tolist()))
+    # Intra-graph edges only
+    assert (0, 1) in pairs
+    assert (1, 0) in pairs
+    assert (2, 3) in pairs
+    assert (3, 2) in pairs
+    # No cross-graph edges
+    assert (0, 2) not in pairs
+    assert (1, 3) not in pairs
+
+
+def test_make_graph_no_pbc_via_make_graph() -> None:
+    """make_graph must route to _make_graph_no_pbc when pbc is all False."""
+    cutoff = 5.0
+    pos = torch.randn(8, 3, dtype=torch.float32)
+    cell = torch.zeros(3, 3)
+    pbc = torch.tensor([False, False, False])
+
+    ei_route, sv_route = AtomsGraph.make_graph(pos, cell, cutoff, pbc)
+    ei_direct, sv_direct = AtomsGraph._make_graph_no_pbc(pos, cutoff)
+
+    assert ei_route.shape == ei_direct.shape
+    assert (sv_route == 0).all()
+
+
+def test_from_atoms_no_pbc_no_cell() -> None:
+    """from_atoms must work for a gas-phase molecule with pbc=False and no cell."""
+    from ase.build import molecule
+    atoms = molecule("H2O")  # pbc=False, cell=zeros by default
+    graph = AtomsGraph.from_atoms(atoms, cutoff=5.0)
+    assert graph.edge_index.shape[0] == 2
+    assert graph.shift_vectors.shape[1] == 3
+    assert (graph.shift_vectors == 0).all()
+


### PR DESCRIPTION
## Summary

- When `pbc` is entirely `False`, the old code built a bounding-box cell so matscipy's cell-list algorithm could run. During diffusion sampling, atoms can spread far apart and this bounding box becomes very large, creating a huge grid and making the neighbor search needlessly slow.
- Adds `_make_graph_no_pbc`: a simple helper that computes neighbors via direct pairwise distances on PyTorch tensors — no cell, no grid, O(N²) but trivially correct and fast enough for molecular/cluster sizes. All shift vectors are zero by construction.
- `make_graph` now short-circuits to `_make_graph_no_pbc` as the first check whenever all `pbc` flags are `False`, bypassing both matscipy and the nvidia cell-list backends entirely.
- The now-unreachable bounding-box workaround inside `_make_graph_matscipy` was removed.

## Test plan

- [ ] `test_make_graph_no_pbc_returns_correct_edges` — correct pairs and zero shift vectors for a hand-crafted positions tensor
- [ ] `test_make_graph_no_pbc_all_pairs_within_cutoff` — all returned edges are within cutoff
- [ ] `test_make_graph_no_pbc_matches_matscipy` — agrees with matscipy on H₂O with a large vacuum cell
- [ ] `test_make_graph_no_pbc_batched` — batched variant produces no cross-graph edges
- [ ] `test_make_graph_no_pbc_via_make_graph` — `make_graph` routes to the new path
- [ ] `test_from_atoms_no_pbc_no_cell` — `from_atoms` works for a gas-phase molecule with no cell
- [ ] Full `tests/data/test_atoms_graph.py` suite (99 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)