### PR TITLE
Fix L-BFGS relaxation across periodic boundaries; add relax API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to AGeDi will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`relax()` API and `agedi relax` command** — run the batched L-BFGS
+  relaxation on structures you supply, independently of diffusion sampling.
+  Each structure in a batch is optimised by its own L-BFGS instance and drops
+  out as soon as its own maximum force falls below `fmax`, and ASE `FixAtoms`
+  constraints on the input are honoured.  `trajectory=True` /
+  `--save_trajectory` returns every optimiser step.
+
+### Fixed
+- **Post-diffusion relaxation no longer breaks on periodic structures.**
+  Positions are wrapped back into the cell after every step, so an atom
+  crossing a cell face reappeared a full lattice vector away; the L-BFGS step
+  sizer reconstructed its displacement by differencing stored positions and so
+  recorded that jump as a history pair.  A single such pair sent the search
+  direction somewhere unrelated to the forces, and because the history holds
+  100 pairs it corrupted the rest of the run — the energy rose instead of
+  falling.  Displacements are now taken in the minimum-image convention.
+  Relaxing an 8-atom periodic Cu cell against exact EMT forces went from
+  10.53 → 15.35 eV (diverging) to 10.53 → 7.60 eV, matching
+  `ase.optimize.LBFGS` to within float32 precision.  Affects
+  `sample(max_extra_steps=...)` and force-field guidance; non-periodic systems
+  were never affected.
+
+### Changed
+- Post-diffusion relaxation now evaluates the force field **once** per step
+  instead of twice — the convergence check's forces are reused by the next
+  step, halving the cost of relaxation.
+- Relaxation convergence is tracked **per structure** rather than across the
+  whole batch: a structure that reaches `force_threshold` stops being stepped
+  instead of continuing until the worst structure in the batch converges.
+
 ## [1.4.0] - 2026-08-11
 
 ### Added

--- a/docs/source/tutorial/cli.rst
+++ b/docs/source/tutorial/cli.rst
@@ -16,6 +16,7 @@ Main commands
 - ``agedi train``: train a diffusion model from a trajectory file or YAML config
 - ``agedi sample``: sample structures from a saved training run
 - ``agedi predict``: predict energies and forces for input structures (requires ``--force_field`` training)
+- ``agedi relax``: relax structures with the trained force field (requires ``--force_field`` training)
 - ``agedi inspect``: print ``hparams.yaml`` from a run directory
 
 To get information about options for each use
@@ -435,6 +436,47 @@ In Python this is equivalent to:
    structures = read("structures.traj", index=":")
    predicted = predict(diffusion, structures)
    write("predicted.traj", predicted)
+
+Relaxing structures
+-------------------
+
+The same L-BFGS optimiser that drives the post-diffusion relaxation is also
+available on its own, with no diffusion sampling involved:
+
+.. code-block:: console
+
+   agedi relax logs/agedi/version_0 structures.traj --fmax 0.05
+
+This reads all structures from ``structures.traj``, relaxes each of them with
+the model's force-field regressor, and writes the results to ``relaxed.traj``.
+Structures are relaxed in batches; each one is optimised by its own L-BFGS
+instance and drops out of the batch as soon as its own maximum force falls
+below ``--fmax``.  ASE ``FixAtoms`` constraints on the input are respected.
+
+Important options:
+
+- ``--fmax``: convergence criterion, maximum per-atom force in eV/Å (default: ``0.05``)
+- ``--steps``: maximum number of optimiser steps per structure (default: ``200``)
+- ``--max_step_size``: maximum single-atom displacement per step, in Å (default: ``0.2``)
+- ``-b/--batch_size``: number of structures relaxed simultaneously (default: ``64``)
+- ``--save_trajectory``: write every optimiser step instead of only the final structure
+
+In Python:
+
+.. code-block:: python
+
+   from ase.io import read, write
+   from agedi import load_diffusion, relax
+
+   diffusion = load_diffusion("logs/agedi/version_0")
+   structures = read("structures.traj", index=":")
+   relaxed = relax(diffusion, structures, fmax=0.05)
+   write("relaxed.traj", relaxed)
+
+The same caveats as for post-diffusion relaxation apply: pick ``fmax`` to suit
+the model's force range, and remember that the ``Forces`` head predicts forces
+directly rather than as :math:`-\partial E/\partial R`, so the field is not
+conservative and has no exact zero-force fixed point.
 
 Inspect run metadata
 --------------------

--- a/src/agedi/__init__.py
+++ b/src/agedi/__init__.py
@@ -18,6 +18,7 @@ from .functional import (
     load_diffusion as load_diffusion,
     predict as predict,
     register_model as register_model,
+    relax as relax,
     sample as sample,
     train as train,
     train_from_atoms as train_from_atoms,
@@ -45,5 +46,6 @@ __all__ = [
     "train_from_config",
     "load_diffusion",
     "predict",
+    "relax",
     "sample",
 ]

--- a/src/agedi/api/__init__.py
+++ b/src/agedi/api/__init__.py
@@ -9,6 +9,7 @@ from .dataset import create_dataset as create_dataset
 from .diffusion import create_diffusion as create_diffusion
 from .diffusion import load_diffusion as load_diffusion
 from .prediction import predict as predict
+from .relaxation import relax as relax
 from .sampling import sample as sample
 from .training import create_trainer as create_trainer
 from .training import train as train
@@ -22,6 +23,7 @@ __all__ = [
     "load_diffusion",
     "predict",
     "register_model",
+    "relax",
     "sample",
     "train",
     "train_from_atoms",

--- a/src/agedi/api/_common.py
+++ b/src/agedi/api/_common.py
@@ -1,0 +1,32 @@
+"""Helpers shared by the inference-side API functions."""
+
+from typing import Optional
+
+
+def resolve_cutoff(diffusion: "Agedi", cutoff: Optional[float] = None) -> float:
+    """Return the neighbour-list cutoff to build graphs with.
+
+    Parameters
+    ----------
+    diffusion:
+        A trained :class:`~agedi.Agedi` model.
+    cutoff:
+        Explicit cutoff in Å.  When ``None`` (default), it is read from the
+        model's representation, falling back to ``6.0`` when the
+        representation does not expose one.
+
+    Returns
+    -------
+    float
+        The cutoff radius in Å.
+    """
+    if cutoff is not None:
+        return float(cutoff)
+
+    try:
+        cf = diffusion.score_model.representation.cutoff_fn
+        if hasattr(cf, "cutoff") and cf.cutoff.numel() > 0:
+            return float(cf.cutoff[0])
+    except AttributeError:
+        pass
+    return 6.0

--- a/src/agedi/api/prediction.py
+++ b/src/agedi/api/prediction.py
@@ -8,6 +8,8 @@ from rich.console import Console
 
 from agedi.data import AtomsGraph
 
+from ._common import resolve_cutoff
+
 
 def predict(
     diffusion: "Agedi",
@@ -56,15 +58,7 @@ def predict(
             "Re-train with force_field=True to enable predictions."
         )
 
-    if cutoff is None:
-        try:
-            cf = diffusion.score_model.representation.cutoff_fn
-            if hasattr(cf, "cutoff") and cf.cutoff.numel() > 0:
-                cutoff = float(cf.cutoff[0])
-            else:
-                cutoff = 6.0
-        except AttributeError:
-            cutoff = 6.0
+    cutoff = resolve_cutoff(diffusion, cutoff)
 
     device = next(diffusion.parameters()).device
 

--- a/src/agedi/api/relaxation.py
+++ b/src/agedi/api/relaxation.py
@@ -1,0 +1,215 @@
+"""Local structure relaxation using a trained force-field regressor."""
+
+from typing import List, Optional, Sequence, Union
+
+import torch
+from ase import Atoms
+from ase.constraints import FixAtoms
+from rich.console import Console
+
+from agedi.data import AtomsGraph
+from agedi.diffusion.guidance import (
+    BatchedLBFGSStepSizer,
+    max_force_per_graph,
+    post_diffusion_relaxation_step,
+)
+
+from ._common import resolve_cutoff
+
+
+def _graph_from_atoms(atoms: Atoms, cutoff: float) -> AtomsGraph:
+    """Build a graph from *atoms*, carrying ``FixAtoms`` over to the mask.
+
+    Masked atoms have their predicted forces zeroed by the regressor and their
+    positions restored on assignment, so the mask is what makes ASE's
+    ``FixAtoms`` constraint take effect during relaxation.
+    """
+    graph = AtomsGraph.from_atoms(atoms, cutoff=cutoff, initialize_mask=True)
+    for constraint in atoms.constraints:
+        if isinstance(constraint, FixAtoms):
+            graph.mask[constraint.index] = True
+    return graph
+
+
+def relax(
+    diffusion: "Agedi",
+    structures: Sequence[Atoms],
+    *,
+    fmax: float = 0.05,
+    steps: int = 200,
+    batch_size: int = 64,
+    cutoff: Optional[float] = None,
+    max_step_size: float = 0.2,
+    trajectory: bool = False,
+    progress_bar: bool = False,
+) -> Union[List[Atoms], List[List[Atoms]]]:
+    """Relax structures with a trained force-field regressor.
+
+    Runs the same batched L-BFGS optimiser that
+    :func:`~agedi.api.sample` uses for its post-diffusion relaxation, but on
+    structures you supply — no diffusion sampling involved.  The algorithm
+    mirrors :class:`ase.optimize.LBFGS`: a constant inverse-Hessian seed, the
+    two-loop recursion, and a per-structure ``maxstep`` cap.
+
+    Each structure in a batch is optimised by its own L-BFGS instance and drops
+    out as soon as its own maximum force falls below *fmax*, so a slow
+    structure never perturbs one that has already converged.
+
+    ASE :class:`~ase.constraints.FixAtoms` constraints on the input are
+    honoured — constrained atoms keep their positions and are excluded from the
+    convergence check.
+
+    Parameters
+    ----------
+    diffusion:
+        A trained :class:`~agedi.Agedi` model with a force-field regressor
+        (trained with ``force_field=True``).
+    structures:
+        Input ASE :class:`~ase.Atoms` objects to relax.
+    fmax:
+        Convergence criterion: the maximum per-atom force magnitude in eV/Å.
+        Defaults to ``0.05``, matching ASE's usual choice.
+    steps:
+        Maximum number of optimiser steps per structure.  Defaults to ``200``.
+    batch_size:
+        Number of structures relaxed simultaneously.  Defaults to ``64``.
+    cutoff:
+        Neighbour-list cutoff in Å.  When ``None`` (default), it is read from
+        the model's representation.
+    max_step_size:
+        Maximum single-atom displacement per step, in Å.  Defaults to ``0.2``
+        (ASE's default).
+    trajectory:
+        When ``True``, return the full relaxation trajectory of every structure
+        instead of only the final frame.
+    progress_bar:
+        Show a per-batch progress bar over optimiser steps.
+
+    Returns
+    -------
+    list
+        The relaxed structures, each with a
+        :class:`~ase.calculators.singlepoint.SinglePointCalculator` holding the
+        predicted energy and forces.  When *trajectory* is ``True``, a list of
+        trajectories (one list of :class:`~ase.Atoms` per input structure),
+        each starting at the input geometry.
+
+    Raises
+    ------
+    ValueError
+        If the model does not have a force-field regressor.
+
+    Examples
+    --------
+    >>> from agedi.api import load_diffusion, relax
+    >>> model = load_diffusion("lightning_logs/version_0")
+    >>> relaxed = relax(model, structures, fmax=0.02)
+    >>> relaxed[0].get_potential_energy()
+    """
+    from torch_geometric.data import Batch
+
+    if diffusion.regressor_model is None:
+        raise ValueError(
+            "This model does not have a force-field regressor. "
+            "Re-train with force_field=True to enable relaxation."
+        )
+
+    cutoff = resolve_cutoff(diffusion, cutoff)
+    device = next(diffusion.parameters()).device
+
+    graphs = [_graph_from_atoms(atoms, cutoff) for atoms in structures]
+    n_structures = len(graphs)
+
+    console = Console()
+    console.print(
+        f"Relaxing {n_structures} structure(s) "
+        f"(fmax={fmax}, max steps={steps}, batch_size={batch_size})..."
+    )
+
+    diffusion.eval()
+    results: List = []
+    n_converged = 0
+
+    with torch.no_grad():
+        for start in range(0, n_structures, batch_size):
+            chunk = graphs[start : start + batch_size]
+            batch = Batch.from_data_list(chunk).to(device)
+            batch.update_graph()
+
+            sizer = BatchedLBFGSStepSizer(
+                batch_size=batch.num_graphs, maxstep=max_step_size
+            )
+
+            batch = diffusion.regressor_model(batch)
+            per_graph_forces = _mobile_max_force(batch)
+
+            frames = [batch.to_data_list()] if trajectory else None
+
+            iterator = range(steps)
+            if progress_bar:
+                from tqdm import tqdm
+
+                iterator = tqdm(iterator, desc="Relaxation")
+
+            for _ in iterator:
+                active = per_graph_forces > fmax
+                if not bool(active.any()):
+                    break
+
+                batch = post_diffusion_relaxation_step(
+                    batch,
+                    diffusion.regressor_model,
+                    sizer,
+                    max_step_size=max_step_size,
+                    forces=batch.forces_prediction,
+                    active=active,
+                )
+                batch = diffusion.regressor_model(batch)
+                per_graph_forces = _mobile_max_force(batch)
+
+                if trajectory:
+                    frames.append(batch.to_data_list())
+
+            n_converged += int((per_graph_forces <= fmax).sum())
+
+            originals = structures[start : start + batch_size]
+            if trajectory:
+                # frames is [step][structure]; transpose to [structure][step].
+                for i, per_structure in enumerate(zip(*frames)):
+                    results.append(
+                        [
+                            _finalise(graph.to_atoms(), originals[i])
+                            for graph in per_structure
+                        ]
+                    )
+            else:
+                for i, graph in enumerate(batch.to_data_list()):
+                    results.append(_finalise(graph.to_atoms(), originals[i]))
+
+    console.print(
+        f"[green]✓[/green] Relaxed {n_structures} structure(s); "
+        f"{n_converged}/{n_structures} reached fmax <= {fmax}"
+    )
+    return results
+
+
+def _finalise(atoms: Atoms, original: Atoms) -> Atoms:
+    """Carry the input constraints over to a relaxed structure."""
+    if original.constraints:
+        atoms.set_constraint(original.constraints)
+    return atoms
+
+
+def _mobile_max_force(batch) -> torch.Tensor:
+    """Per-graph maximum force over the *mobile* atoms only.
+
+    A fixed atom may carry a large force without that meaning anything for
+    convergence — it cannot move.  The regressor normally zeroes those forces
+    itself (``mask_forces=True``), but that is configurable, so the mask is
+    applied here explicitly.
+    """
+    forces = batch.forces_prediction
+    if "mask" in batch:
+        forces = forces.clone()
+        forces[batch.positions_mask] = 0.0
+    return max_force_per_graph(forces, batch.batch, batch.num_graphs)

--- a/src/agedi/cli/main.py
+++ b/src/agedi/cli/main.py
@@ -4,6 +4,7 @@ from agedi.cli.train_hydra import train_hydra
 from agedi.cli.sample import sample
 from agedi.cli.inspect import inspect
 from agedi.cli.predict import predict
+from agedi.cli.relax import relax
 
 @click.group()
 @click.version_option()
@@ -16,4 +17,5 @@ cli.add_command(train_hydra)
 cli.add_command(sample)
 cli.add_command(inspect)
 cli.add_command(predict)
+cli.add_command(relax)
 

--- a/src/agedi/cli/relax.py
+++ b/src/agedi/cli/relax.py
@@ -1,0 +1,147 @@
+import rich_click as click
+from rich.console import Console
+from pathlib import Path
+
+
+click.rich_click.OPTION_GROUPS.update(
+    {
+        "agedi relax": [
+            {"name": "Model Options", "options": ["path"]},
+            {
+                "name": "Relaxation Options",
+                "options": [
+                    "--fmax",
+                    "--steps",
+                    "--max_step_size",
+                    "--batch_size",
+                ],
+            },
+            {
+                "name": "Input / Output Options",
+                "options": [
+                    "--output",
+                    "--name",
+                    "--save_trajectory",
+                    "--progress_bar",
+                ],
+            },
+        ]
+    }
+)
+
+
+@click.command()
+@click.argument("path", type=click.Path(exists=True))
+@click.argument("input_path", metavar="INPUT", type=click.Path(exists=True))
+@click.option(
+    "--fmax",
+    type=float,
+    show_default=True,
+    default=0.05,
+    help="Convergence criterion: maximum per-atom force in eV/Å.",
+)
+@click.option(
+    "--steps",
+    type=int,
+    show_default=True,
+    default=200,
+    help="Maximum number of L-BFGS steps per structure.",
+)
+@click.option(
+    "--max_step_size",
+    type=float,
+    show_default=True,
+    default=0.2,
+    help="Maximum single-atom displacement per step, in Å (ASE's maxstep).",
+)
+@click.option(
+    "--batch_size",
+    "-b",
+    type=int,
+    show_default=True,
+    default=64,
+    help="Number of structures relaxed simultaneously.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    show_default=True,
+    default=".",
+    help="Directory to save the output trajectory to.",
+)
+@click.option(
+    "--name",
+    type=str,
+    show_default=True,
+    default="relaxed",
+    help="Base name for the output trajectory file (without extension).",
+)
+@click.option(
+    "--save_trajectory",
+    is_flag=True,
+    help="Save every optimiser step instead of only the final structure.",
+)
+@click.option("--progress_bar", is_flag=True, help="Show progress bar")
+def relax(path: str, input_path: str, **kwargs) -> None:
+    """Relax structures in INPUT with a trained force field.
+
+    Loads the trained AGeDi model from PATH and runs a batched L-BFGS
+    relaxation — equivalent to ``ase.optimize.LBFGS`` — driven by the model's
+    force-field regressor.  No diffusion sampling is involved.
+
+    ASE ``FixAtoms`` constraints on the input structures are respected.
+
+    The model must have been trained with the ``--force_field`` flag.
+    """
+    from ase.io import read, write
+    from agedi.functional import load_diffusion, relax as functional_relax
+
+    console = Console()
+    console.print(f"Loading model from: [cyan]{path}[/cyan]")
+
+    diffusion = load_diffusion(path)
+
+    if diffusion.regressor_model is None:
+        console.print(
+            "[red]Error:[/red] This model does not have a force-field regressor. "
+            "Re-train with [bold]--force_field[/bold] to enable relaxation."
+        )
+        raise SystemExit(1)
+
+    console.print(f"Reading structures from: [cyan]{input_path}[/cyan]")
+    structures = read(input_path, index=":")
+    if not isinstance(structures, list):
+        structures = [structures]
+
+    relaxed = functional_relax(
+        diffusion,
+        structures,
+        fmax=kwargs["fmax"],
+        steps=kwargs["steps"],
+        batch_size=kwargs["batch_size"],
+        max_step_size=kwargs["max_step_size"],
+        trajectory=kwargs["save_trajectory"],
+        progress_bar=kwargs["progress_bar"],
+    )
+
+    output_dir = Path(kwargs["output"])
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / f"{kwargs['name']}.traj"
+
+    if kwargs["save_trajectory"]:
+        # Flatten per-structure trajectories into one file, in order.
+        frames = [atoms for traj in relaxed for atoms in traj]
+        write(str(out_path), frames)
+        console.print(
+            f"[green]✓[/green] Saved {len(frames)} frame(s) from "
+            f"{len(relaxed)} structure(s) to: [cyan]{out_path}[/cyan]"
+        )
+    else:
+        write(str(out_path), relaxed)
+        console.print(
+            f"[green]✓[/green] Saved {len(relaxed)} structure(s) to: [cyan]{out_path}[/cyan]"
+        )
+
+    console.print("To inspect the relaxed structures, load the trajectory in ASE:")
+    console.print(f"  [bold]ase gui {out_path}[/bold]")

--- a/src/agedi/diffusion/diffusion.py
+++ b/src/agedi/diffusion/diffusion.py
@@ -26,6 +26,7 @@ from .guidance import (
     BatchedLBFGSStepSizer,
     ForcefieldGuidanceConfig,
     force_field_guidance_step,
+    max_force_per_graph,
     post_diffusion_relaxation_step,
 )
 
@@ -440,6 +441,8 @@ class Diffusion:
         batch: AtomsGraph,
         scale: float = 1.0,
         max_step_size: float = 0.2,
+        forces: Optional[torch.Tensor] = None,
+        active: Optional[torch.Tensor] = None,
     ) -> AtomsGraph:
         """Perform one L-BFGS relaxation step, as ``ase.optimize.LBFGS`` would.
 
@@ -453,6 +456,12 @@ class Diffusion:
         max_step_size : float, optional
             Maximum single-atom displacement per step, in Å.  Defaults to
             ``0.2``, matching ASE.
+        forces : torch.Tensor, optional
+            Forces at the current positions.  Supplying them skips the
+            regressor call inside the step.
+        active : torch.Tensor, optional
+            Boolean mask over graphs; structures marked ``False`` are left
+            untouched.
 
         Returns
         -------
@@ -465,6 +474,8 @@ class Diffusion:
             self.lbfgs_step_sizer,
             scale=scale,
             max_step_size=max_step_size,
+            forces=forces,
+            active=active,
         )
 
     # ------------------------------------------------------------------
@@ -981,7 +992,13 @@ class Diffusion:
                     self.regressor_model,
                     batch,
                 )
-            max_forces = torch.norm(batch.forces_prediction, dim=1).max(dim=0)[0]
+            # Convergence is tracked per structure: a batch-wide maximum keeps
+            # every structure stepping until the worst one is done, jostling
+            # the ones that already converged.
+            per_graph_forces = max_force_per_graph(
+                batch.forces_prediction, batch.batch, batch.num_graphs
+            )
+            max_forces = per_graph_forces.max()
 
             if max_forces > force_threshold and max_extra_steps > 0:
                 if progress_bar:
@@ -1000,11 +1017,21 @@ class Diffusion:
                 )
 
                 for i in extra_iterator:
+                    # Structures already below the threshold sit out the rest
+                    # of the relaxation instead of being stepped further.
+                    active = per_graph_forces > force_threshold
+                    # The forces were evaluated at exactly these positions by
+                    # the convergence check (or the initial eval above), so
+                    # they are passed in rather than recomputed.
+                    forces = batch.forces_prediction
+
                     # Full L-BFGS step (ASE damping=1.0).  Scaling the step
                     # down here would slow convergence without improving
                     # stability — the maxstep limit is what bounds the step.
                     if timings is None:
-                        batch = self.post_diffusion_relaxation_step(batch)
+                        batch = self.post_diffusion_relaxation_step(
+                            batch, forces=forces, active=active
+                        )
                     else:
                         batch = self._time_sampling_call(
                             batch.pos.device,
@@ -1012,6 +1039,8 @@ class Diffusion:
                             "post_diffusion_relaxation",
                             self.post_diffusion_relaxation_step,
                             batch,
+                            forces=forces,
+                            active=active,
                         )
                         timings.post_diffusion_relaxation_steps += 1
 
@@ -1025,9 +1054,10 @@ class Diffusion:
                             self.regressor_model,
                             batch,
                         )
-                    max_forces = torch.norm(batch.forces_prediction, dim=1).max(
-                        dim=0
-                    )[0]
+                    per_graph_forces = max_force_per_graph(
+                        batch.forces_prediction, batch.batch, batch.num_graphs
+                    )
+                    max_forces = per_graph_forces.max()
 
                     if save_trajectory:
                         path.append(batch.to_data_list())

--- a/src/agedi/diffusion/guidance.py
+++ b/src/agedi/diffusion/guidance.py
@@ -6,17 +6,100 @@ This module provides:
 - :class:`BatchedLBFGSStepSizer` – batched wrapper around :class:`LBFGSStepSizer`.
 - :func:`force_field_guidance_step` – one guidance step (module-level).
 - :func:`post_diffusion_relaxation_step` – post-diffusion relaxation (module-level).
+- :func:`max_force_per_graph` – per-structure convergence measure.
 """
 
 from __future__ import annotations
 
 import dataclasses
 from collections import deque
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 
 from agedi.data import AtomsGraph
+
+
+def minimum_image(
+    d: torch.Tensor,
+    cell: Optional[torch.Tensor],
+    pbc: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """Map displacement vectors to their shortest periodic image.
+
+    Positions are wrapped back into the unit cell after every step (see
+    :meth:`~agedi.data.AtomsGraph.wrap_positions`), so differencing two stored
+    position tensors reports a full lattice vector whenever an atom crossed a
+    cell face — even though the atom barely moved.  Feeding such a displacement
+    into the L-BFGS history destroys the curvature estimate, so every
+    displacement reconstructed from stored positions must pass through here
+    first.
+
+    Parameters
+    ----------
+    d : torch.Tensor
+        Displacement vectors, shape ``(n_atoms, 3)``.
+    cell : torch.Tensor or None
+        Unit cell of the structure, shape ``(3, 3)``, row-vector convention
+        (``r = f @ cell``).  ``None`` disables the correction.
+    pbc : torch.Tensor or None
+        Boolean periodicity flags, shape ``(3,)``.  Non-periodic directions are
+        left untouched.  ``None`` disables the correction.
+
+    Returns
+    -------
+    torch.Tensor
+        Displacements with any lattice-vector jumps removed.
+    """
+    if cell is None or pbc is None or not bool(pbc.any()):
+        return d
+
+    cell = cell.view(3, 3).to(d.dtype)
+    # Degenerate (zero) cells appear on non-periodic graphs; nothing to wrap.
+    if not bool(torch.linalg.det(cell).abs() > 1e-12):
+        return d
+
+    # r = f @ cell  =>  f = solve(cell.T, r.T).T   (matches AtomsGraph.pos_to_frac)
+    frac = torch.linalg.solve(cell.transpose(0, 1), d.transpose(0, 1)).transpose(0, 1)
+    shift = torch.round(frac) * pbc.to(frac.dtype)
+    return d - shift @ cell
+
+
+def max_force_per_graph(
+    forces: torch.Tensor, batch_idx: torch.Tensor, num_graphs: int
+) -> torch.Tensor:
+    """Return the maximum per-atom force magnitude of every graph in a batch.
+
+    Relaxation convergence is a per-structure property: taking the maximum over
+    the whole batch keeps every structure stepping until the worst one is done.
+
+    Parameters
+    ----------
+    forces : torch.Tensor
+        Per-atom forces, shape ``(n_atoms, 3)``.
+    batch_idx : torch.Tensor
+        Graph membership index (``batch.batch``), shape ``(n_atoms,)``.
+    num_graphs : int
+        Number of graphs in the batch.
+
+    Returns
+    -------
+    torch.Tensor
+        Maximum force magnitude per graph, shape ``(num_graphs,)``.
+    """
+    norms = torch.norm(forces, dim=1)
+    out = torch.zeros(num_graphs, dtype=norms.dtype, device=norms.device)
+    out.scatter_reduce_(0, batch_idx, norms, reduce="amax")
+    return out
+
+
+def _cell_and_pbc(batch: AtomsGraph) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    """Extract per-graph ``(cell, pbc)`` tensors from *batch*, if available."""
+    cell = getattr(batch, "cell", None)
+    pbc = getattr(batch, "pbc", None)
+    if cell is None or pbc is None:
+        return None, None
+    return cell.view(-1, 3, 3), pbc.view(-1, 3)
 
 
 @dataclasses.dataclass
@@ -110,6 +193,8 @@ class LBFGSStepSizer:
         pos: torch.Tensor,
         forces: torch.Tensor,
         maxstep: Optional[float] = None,
+        cell: Optional[torch.Tensor] = None,
+        pbc: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Compute the L-BFGS displacement for one structure.
 
@@ -122,6 +207,15 @@ class LBFGSStepSizer:
             i.e. the *negative* gradient.
         maxstep : float, optional
             Overrides :attr:`maxstep` for this call.
+        cell : torch.Tensor, optional
+            Unit cell, shape ``(3, 3)``.  Required together with *pbc* for
+            periodic structures so that the displacement reconstructed from
+            stored positions is taken in the minimum-image convention; without
+            it, an atom that wrapped across a cell face injects a
+            lattice-vector-sized ``s0`` into the history and the search
+            direction stops following the forces.
+        pbc : torch.Tensor, optional
+            Boolean periodicity flags, shape ``(3,)``.
 
         Returns
         -------
@@ -130,7 +224,7 @@ class LBFGSStepSizer:
         """
         # --- Update history (ASE: LBFGS.update) ---
         if self.prev_pos is not None:
-            s0 = pos - self.prev_pos
+            s0 = minimum_image(pos - self.prev_pos, cell, pbc)
             # We use the gradient, which is minus the force.
             y0 = self.prev_forces - forces
             ys = torch.sum(y0 * s0)
@@ -237,6 +331,9 @@ class BatchedLBFGSStepSizer:
         forces: torch.Tensor,
         batch_idx: torch.Tensor,
         maxstep: Optional[float] = None,
+        cell: Optional[torch.Tensor] = None,
+        pbc: Optional[torch.Tensor] = None,
+        active: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Compute steps for batched data.
 
@@ -254,6 +351,17 @@ class BatchedLBFGSStepSizer:
             Index tensor mapping each atom to its graph in the batch.
         maxstep : float, optional
             Overrides the per-sizer step limit for this call.
+        cell : torch.Tensor, optional
+            Per-graph cells, shape ``(num_graphs, 3, 3)``.  Forwarded to
+            :meth:`LBFGSStepSizer.compute_step` for the minimum-image
+            correction.
+        pbc : torch.Tensor, optional
+            Per-graph periodicity flags, shape ``(num_graphs, 3)``.
+        active : torch.Tensor, optional
+            Boolean mask over graphs, shape ``(num_graphs,)``.  Graphs marked
+            ``False`` get a zero step and their L-BFGS history is left
+            untouched, so a structure that has already converged is not
+            disturbed while the rest of the batch keeps relaxing.
 
         Returns
         -------
@@ -266,10 +374,16 @@ class BatchedLBFGSStepSizer:
         # into a list and re-enumerating would misalign every graph after an
         # empty one, silently giving atoms another structure's step.
         for i, step_sizer in enumerate(self.step_sizers):
+            if active is not None and not bool(active[i]):
+                continue
             mask = batch_idx == i
             if torch.any(mask):
                 combined_step[mask] = step_sizer.compute_step(
-                    pos[mask], forces[mask], maxstep=maxstep
+                    pos[mask],
+                    forces[mask],
+                    maxstep=maxstep,
+                    cell=None if cell is None else cell[i],
+                    pbc=None if pbc is None else pbc[i],
                 )
 
         return combined_step
@@ -335,8 +449,9 @@ def force_field_guidance_step(
     # Use L-BFGS to compute the step direction and magnitude.  The sizer caps
     # the displacement per structure, scaling the whole step uniformly so the
     # search direction is preserved; guidance strength is then applied on top.
+    cell, pbc = _cell_and_pbc(batch)
     lbfgs_step = lbfgs_step_sizer.compute_step(
-        positions, forces, batch_idx, maxstep=max_step_size
+        positions, forces, batch_idx, maxstep=max_step_size, cell=cell, pbc=pbc
     )
 
     step = scale * time_factor * lbfgs_step
@@ -368,6 +483,8 @@ def post_diffusion_relaxation_step(
     lbfgs_step_sizer: Optional[BatchedLBFGSStepSizer],
     scale: float = 1.0,
     max_step_size: float = 0.2,
+    forces: Optional[torch.Tensor] = None,
+    active: Optional[torch.Tensor] = None,
 ) -> AtomsGraph:
     """Perform one L-BFGS relaxation step after diffusion is complete.
 
@@ -390,6 +507,14 @@ def post_diffusion_relaxation_step(
     max_step_size : float, optional
         Maximum single-atom displacement per step, in Å.  Defaults to ``0.2``
         (ASE's default).  Applied by scaling the whole step uniformly.
+    forces : torch.Tensor, optional
+        Forces at the current positions.  When given, *regressor_model* is not
+        called: the caller's convergence check already evaluated the forces at
+        exactly these positions, and re-evaluating them here would double the
+        cost of every relaxation step.
+    active : torch.Tensor, optional
+        Boolean mask over graphs, shape ``(num_graphs,)``.  Structures marked
+        ``False`` are left untouched.
 
     Returns
     -------
@@ -399,22 +524,30 @@ def post_diffusion_relaxation_step(
     if regressor_model is None:
         return batch
 
-    # Get forces from regressor model
-    batch = regressor_model(batch)
+    if forces is None:
+        # Get forces from regressor model
+        batch = regressor_model(batch)
 
-    if "forces_prediction" not in batch:
-        raise ValueError("Regressor model does not compute forces.")
+        if "forces_prediction" not in batch:
+            raise ValueError("Regressor model does not compute forces.")
+        forces = batch.forces_prediction
 
     positions = batch.pos
-    forces = batch.forces_prediction
     batch_idx = batch.batch
 
     if lbfgs_step_sizer is None:
         lbfgs_step_sizer = BatchedLBFGSStepSizer(batch_size=batch.batch_size)
 
     # The sizer already applies the maxstep limit, uniformly per structure.
+    cell, pbc = _cell_and_pbc(batch)
     step = scale * lbfgs_step_sizer.compute_step(
-        positions, forces, batch_idx, maxstep=max_step_size
+        positions,
+        forces,
+        batch_idx,
+        maxstep=max_step_size,
+        cell=cell,
+        pbc=pbc,
+        active=active,
     )
 
     new_pos = batch.pos + step

--- a/src/agedi/functional.py
+++ b/src/agedi/functional.py
@@ -15,6 +15,7 @@ from agedi.api import (  # noqa: F401
     load_diffusion,
     predict,
     register_model,
+    relax,
     sample,
     train,
 )
@@ -54,6 +55,7 @@ __all__ = [
     "load_diffusion",
     "predict",
     "register_model",
+    "relax",
     "sample",
     "train",
     "train_from_atoms",

--- a/tests/diffusion/test_relaxation.py
+++ b/tests/diffusion/test_relaxation.py
@@ -1,0 +1,307 @@
+"""Regression tests for the L-BFGS relaxation used by ``max_extra_steps``.
+
+The regressor is replaced by an exact analytic force field, so any failure to
+reach the minimum is a defect in the optimiser rather than model error.
+"""
+
+import numpy as np
+import pytest
+import torch
+from ase import Atoms
+from torch_geometric.data import Batch
+
+from agedi.data import AtomsGraph
+from agedi.diffusion.guidance import (
+    BatchedLBFGSStepSizer,
+    LBFGSStepSizer,
+    max_force_per_graph,
+    minimum_image,
+    post_diffusion_relaxation_step,
+)
+
+L = 10.0
+K = 4.0  # eV/Å², spring constant of the toy potential
+
+
+def _mic(d: np.ndarray) -> np.ndarray:
+    """Minimum-image displacement in the cubic cell of side ``L``."""
+    return d - L * np.round(d / L)
+
+
+class HarmonicField:
+    """Exact PES: every atom is bound to its own site by a spring.
+
+    ``U = 0.5 K Σ |mic(r_i - r0_i)|²`` — periodic, conservative, and with a
+    single known minimum at ``r0``, so the optimiser has nowhere to hide.
+    """
+
+    def __init__(self, sites: np.ndarray):
+        self.sites = sites
+        self.calls = 0
+
+    def __call__(self, batch):
+        self.calls += 1
+        pos = batch.pos.detach().cpu().numpy().astype(float)
+        sites = np.tile(self.sites, (batch.num_graphs, 1))[: len(pos)]
+        d = _mic(pos - sites)
+        batch["forces_prediction"] = torch.tensor(-K * d, dtype=batch.pos.dtype)
+        return batch
+
+    def energy(self, batch) -> float:
+        pos = batch.pos.detach().cpu().numpy().astype(float)
+        sites = np.tile(self.sites, (batch.num_graphs, 1))[: len(pos)]
+        return float(0.5 * K * (_mic(pos - sites) ** 2).sum())
+
+
+def _sites(on_boundary: bool) -> np.ndarray:
+    """Four equilibrium sites, either straddling a cell face or mid-cell."""
+    base = np.array([[0.0, 2.0, 2.0], [0.0, 5.0, 2.0], [0.0, 2.0, 5.0], [0.0, 5.0, 5.0]])
+    base[:, 0] = 0.02 if on_boundary else 5.0
+    return base
+
+
+def _build(on_boundary: bool, n_structures: int = 1, displacement: float = 0.35):
+    """Batch of Cu4 structures displaced from the minimum of :class:`HarmonicField`."""
+    sites = _sites(on_boundary)
+    rng = np.random.default_rng(0)
+    graphs = []
+    for _ in range(n_structures):
+        pos = (sites + rng.normal(scale=displacement, size=sites.shape)) % L
+        atoms = Atoms("Cu4", positions=pos, cell=np.eye(3) * L, pbc=True)
+        graphs.append(AtomsGraph.from_atoms(atoms, cutoff=6.0))
+    batch = Batch.from_data_list(graphs)
+    batch.update_graph()
+    return batch, HarmonicField(sites)
+
+
+def _relax(batch, field, steps=60, sizer=None):
+    """Drive ``post_diffusion_relaxation_step`` the way ``_sample_batch`` does."""
+    if sizer is None:
+        sizer = BatchedLBFGSStepSizer(batch_size=batch.num_graphs)
+    batch = field(batch)
+    for _ in range(steps):
+        batch = post_diffusion_relaxation_step(
+            batch, field, sizer, forces=batch.forces_prediction
+        )
+        batch = field(batch)
+    return batch
+
+
+class TestMinimumImage:
+    """The displacement correction that keeps the L-BFGS history sane."""
+
+    def test_removes_lattice_jump(self):
+        cell = torch.eye(3) * L
+        pbc = torch.tensor([True, True, True])
+        d = torch.tensor([[9.8, 0.0, 0.0]])
+        assert torch.allclose(
+            minimum_image(d, cell, pbc), torch.tensor([[-0.2, 0.0, 0.0]]), atol=1e-5
+        )
+
+    def test_leaves_small_displacements_untouched(self):
+        cell = torch.eye(3) * L
+        pbc = torch.tensor([True, True, True])
+        d = torch.tensor([[0.1, -0.2, 0.05]])
+        assert torch.allclose(minimum_image(d, cell, pbc), d, atol=1e-6)
+
+    def test_non_periodic_directions_are_not_wrapped(self):
+        cell = torch.eye(3) * L
+        pbc = torch.tensor([True, False, False])
+        d = torch.tensor([[9.8, 9.8, 0.0]])
+        out = minimum_image(d, cell, pbc)
+        assert out[0, 0] == pytest.approx(-0.2, abs=1e-5)
+        assert out[0, 1] == pytest.approx(9.8, abs=1e-5)
+
+    def test_no_cell_is_a_no_op(self):
+        d = torch.tensor([[9.8, 0.0, 0.0]])
+        assert torch.allclose(minimum_image(d, None, None), d)
+
+
+class TestLBFGSHistoryAcrossPeriodicBoundary:
+    """The mechanism this module exists for.
+
+    ``wrap_positions`` maps every position back into the cell after each step,
+    so an atom crossing a face reappears a full lattice vector away.  The
+    displacement the step sizer reconstructs by differencing stored positions
+    must not contain that jump — one such history pair is enough to send the
+    search direction somewhere unrelated to the forces.
+    """
+
+    def test_a_wrap_actually_happens_in_this_fixture(self):
+        """Guard the guard: the test below is only meaningful if atoms wrap."""
+        batch, field = _build(on_boundary=True)
+        before = batch.pos.clone()
+        _relax(batch, field, steps=12)
+        # Some atom must have crossed the face for the regression to be exercised.
+        assert (batch.pos - before).abs().max() > L / 2
+
+    def test_history_contains_no_lattice_jump(self):
+        batch, field = _build(on_boundary=True)
+        sizer = BatchedLBFGSStepSizer(batch_size=batch.num_graphs)
+        _relax(batch, field, steps=12, sizer=sizer)
+
+        stored = sizer.step_sizers[0].s_list
+        assert stored, "no history was accumulated"
+        longest = max(float(s.abs().max()) for s in stored)
+        # Every step is capped at maxstep=0.2 A; anything near L is a wrap that
+        # leaked into the history.
+        assert longest < L / 2
+
+
+class TestRelaxationOnEMT:
+    """End-to-end behaviour on a real PES, with atoms on the cell face."""
+
+    @staticmethod
+    def _setup():
+        emt = pytest.importorskip("ase.calculators.emt")
+
+        rng = np.random.default_rng(0)
+        pos = np.array(
+            [[0.0, 0.0, 0.0], [2.6, 0.0, 0.0], [0.0, 2.6, 0.0], [2.6, 2.6, 0.0],
+             [1.3, 1.3, 2.3], [3.9, 1.3, 2.3], [1.3, 3.9, 2.3], [3.9, 3.9, 2.3]]
+        ) + rng.normal(scale=0.15, size=(8, 3))
+        pos[:, 0] += 9.98 - pos[0, 0]  # first atom sits on the cell face
+        pos %= L
+
+        def make_atoms(p):
+            a = Atoms("Cu8", positions=p, cell=np.eye(3) * L, pbc=True)
+            a.calc = emt.EMT()
+            return a
+
+        def regressor(batch):
+            a = make_atoms(batch.pos.detach().cpu().numpy().astype(float))
+            batch["forces_prediction"] = torch.tensor(
+                a.get_forces(), dtype=batch.pos.dtype
+            )
+            return batch
+
+        return pos, make_atoms, regressor
+
+    @classmethod
+    def _relax_emt(cls, steps=40):
+        pos, make_atoms, regressor = cls._setup()
+        batch = Batch.from_data_list(
+            [AtomsGraph.from_atoms(make_atoms(pos), cutoff=6.0)]
+        )
+        batch.update_graph()
+        sizer = BatchedLBFGSStepSizer(batch_size=1)
+        batch = regressor(batch)
+        for _ in range(steps):
+            batch = post_diffusion_relaxation_step(
+                batch, regressor, sizer, forces=batch.forces_prediction
+            )
+            batch = regressor(batch)
+        final = make_atoms(batch.pos.detach().cpu().numpy().astype(float))
+        return make_atoms(pos), final
+
+    def test_energy_decreases(self):
+        """Pre-fix this rose by ~4.8 eV instead of falling."""
+        start, final = self._relax_emt()
+        assert final.get_potential_energy() < start.get_potential_energy()
+
+    def test_forces_decrease(self):
+        start, final = self._relax_emt()
+        f_start = np.abs(start.get_forces()).max()
+        f_final = np.abs(final.get_forces()).max()
+        assert f_final < 0.5 * f_start
+
+    def test_matches_ase_lbfgs(self):
+        """End-to-end parity with ``ase.optimize.LBFGS``."""
+        from ase.optimize import LBFGS as ASELBFGS
+
+        start, final = self._relax_emt()
+        reference = start
+        ASELBFGS(reference, logfile=None).run(fmax=1e-3, steps=40)
+
+        # Tolerance is set by graph positions being float32, not by the
+        # optimiser: before the minimum-image fix the gap here was ~2 eV.
+        assert final.get_potential_energy() == pytest.approx(
+            reference.get_potential_energy(), abs=5e-3
+        )
+
+
+class TestForceEvaluationCount:
+    """Forces are evaluated once per step, not twice."""
+
+    def test_supplied_forces_skip_the_regressor_call(self):
+        batch, field = _build(on_boundary=False)
+        batch = field(batch)
+        calls_before = field.calls
+        post_diffusion_relaxation_step(
+            batch, field, BatchedLBFGSStepSizer(batch_size=1),
+            forces=batch.forces_prediction,
+        )
+        assert field.calls == calls_before
+
+    def test_omitted_forces_still_evaluate(self):
+        batch, field = _build(on_boundary=False)
+        calls_before = field.calls
+        post_diffusion_relaxation_step(
+            batch, field, BatchedLBFGSStepSizer(batch_size=1)
+        )
+        assert field.calls == calls_before + 1
+
+    def test_relaxation_loop_uses_one_evaluation_per_step(self):
+        steps = 10
+        batch, field = _build(on_boundary=False)
+        _relax(batch, field, steps=steps)
+        # 1 initial evaluation + 1 per step.
+        assert field.calls == steps + 1
+
+
+class TestPerStructureConvergence:
+    """A converged structure sits out the rest of the batch's relaxation."""
+
+    def test_inactive_structures_do_not_move(self):
+        batch, field = _build(on_boundary=False, n_structures=2)
+        batch = field(batch)
+        before = batch.pos.clone()
+        active = torch.tensor([True, False])
+        batch = post_diffusion_relaxation_step(
+            batch,
+            field,
+            BatchedLBFGSStepSizer(batch_size=2),
+            forces=batch.forces_prediction,
+            active=active,
+        )
+        moved_0 = (batch.pos[batch.batch == 0] - before[batch.batch == 0]).abs().max()
+        moved_1 = (batch.pos[batch.batch == 1] - before[batch.batch == 1]).abs().max()
+        assert moved_0 > 0
+        assert moved_1 == 0
+
+    def test_inactive_structure_history_is_untouched(self):
+        batch, field = _build(on_boundary=False, n_structures=2)
+        batch = field(batch)
+        sizer = BatchedLBFGSStepSizer(batch_size=2)
+        post_diffusion_relaxation_step(
+            batch, field, sizer,
+            forces=batch.forces_prediction,
+            active=torch.tensor([True, False]),
+        )
+        assert sizer.step_sizers[0].prev_pos is not None
+        assert sizer.step_sizers[1].prev_pos is None
+
+
+class TestMaxForcePerGraph:
+    """Per-structure convergence measure."""
+
+    def test_reports_each_graph_separately(self):
+        forces = torch.tensor(
+            [[3.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.5]]
+        )
+        batch_idx = torch.tensor([0, 0, 1])
+        out = max_force_per_graph(forces, batch_idx, 2)
+        assert out[0] == pytest.approx(3.0)
+        assert out[1] == pytest.approx(0.5)
+
+
+class TestLBFGSStepSizerDirection:
+    """The very first step, with no history, must follow the forces."""
+
+    def test_first_step_is_along_the_forces(self):
+        sizer = LBFGSStepSizer()
+        pos = torch.zeros(2, 3)
+        forces = torch.tensor([[1.0, 0.0, 0.0], [0.0, -2.0, 0.0]])
+        step = sizer.compute_step(pos, forces)
+        assert torch.all(step * forces >= 0)
+        assert (step * forces).sum() > 0

--- a/tests/test_relax_api.py
+++ b/tests/test_relax_api.py
@@ -1,0 +1,219 @@
+"""Tests for the standalone ``relax`` API."""
+
+import numpy as np
+import pytest
+import torch
+from ase import Atoms
+from ase.constraints import FixAtoms
+
+from agedi.api import relax
+
+emt = pytest.importorskip("ase.calculators.emt")
+
+L = 12.0
+
+
+class EMTRegressor(torch.nn.Module):
+    """Stand-in for a trained forces head: exact EMT forces.
+
+    Mirrors :class:`~agedi.models.RegressorModel` closely enough for the API —
+    predictions are registered as node attributes and masked atoms get zero
+    force.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.dummy = torch.nn.Parameter(torch.zeros(1))
+        self.calls = 0
+
+    def forward(self, batch):
+        self.calls += 1
+        pos = batch.pos.detach().cpu().numpy().astype(float)
+        forces = np.zeros_like(pos)
+        offset = 0
+        for i in range(batch.num_graphs):
+            sel = (batch.batch == i).cpu().numpy()
+            n = int(sel.sum())
+            atoms = Atoms(
+                numbers=batch.x[torch.tensor(sel)].cpu().numpy(),
+                positions=pos[sel],
+                cell=np.eye(3) * L,
+                pbc=True,
+            )
+            atoms.calc = emt.EMT()
+            forces[sel] = atoms.get_forces()
+            offset += n
+        f = torch.tensor(forces, dtype=batch.pos.dtype)
+        if "mask" in batch:
+            f[batch.positions_mask] = 0.0
+        batch.add_batch_attr("forces_prediction", f, type="node")
+        return batch
+
+
+class FakeModel(torch.nn.Module):
+    """Minimal stand-in for :class:`~agedi.Agedi` as ``relax`` uses it."""
+
+    def __init__(self, regressor=None):
+        super().__init__()
+        self.regressor_model = regressor
+        self.score_model = None
+
+
+def _structure(displacement=0.25, seed=0):
+    rng = np.random.default_rng(seed)
+    pos = np.array(
+        [[0.0, 0.0, 0.0], [2.6, 0.0, 0.0], [0.0, 2.6, 0.0], [2.6, 2.6, 0.0]]
+    ) + rng.normal(scale=displacement, size=(4, 3))
+    pos[:, 0] += 11.98 - pos[0, 0]  # straddle the periodic boundary
+    return Atoms("Cu4", positions=pos % L, cell=np.eye(3) * L, pbc=True)
+
+
+def _fmax(atoms):
+    a = atoms.copy()
+    a.calc = emt.EMT()
+    return float(np.abs(a.get_forces()).max())
+
+
+def _energy(atoms):
+    a = atoms.copy()
+    a.calc = emt.EMT()
+    return float(a.get_potential_energy())
+
+
+@pytest.fixture
+def model():
+    return FakeModel(EMTRegressor())
+
+
+class TestRelaxBasics:
+    def test_returns_one_structure_per_input(self, model):
+        structures = [_structure(seed=i) for i in range(3)]
+        out = relax(model, structures, fmax=0.05, steps=5, cutoff=6.0)
+        assert len(out) == 3
+        assert all(isinstance(a, Atoms) for a in out)
+
+    def test_attaches_predicted_forces(self, model):
+        out = relax(model, [_structure()], fmax=0.05, steps=5, cutoff=6.0)
+        assert out[0].calc is not None
+        assert out[0].get_forces().shape == (4, 3)
+
+    def test_preserves_composition_and_cell(self, model):
+        original = _structure()
+        out = relax(model, [original], fmax=0.05, steps=5, cutoff=6.0)[0]
+        assert out.get_chemical_symbols() == original.get_chemical_symbols()
+        assert np.allclose(out.get_cell(), original.get_cell())
+
+    def test_does_not_mutate_the_input(self, model):
+        original = _structure()
+        before = original.get_positions().copy()
+        relax(model, [original], fmax=0.05, steps=10, cutoff=6.0)
+        assert np.allclose(original.get_positions(), before)
+
+    def test_requires_a_regressor(self):
+        with pytest.raises(ValueError, match="force-field regressor"):
+            relax(FakeModel(None), [_structure()])
+
+
+class TestRelaxConverges:
+    def test_reduces_forces(self, model):
+        structure = _structure()
+        out = relax(model, [structure], fmax=0.05, steps=60, cutoff=6.0)[0]
+        assert _fmax(out) < _fmax(structure)
+
+    def test_reduces_energy(self, model):
+        structure = _structure()
+        out = relax(model, [structure], fmax=0.05, steps=60, cutoff=6.0)[0]
+        assert _energy(out) < _energy(structure)
+
+    def test_stops_early_once_converged(self, model):
+        """A structure already inside fmax costs one force evaluation, not `steps`."""
+        relaxed = relax(model, [_structure()], fmax=0.05, steps=60, cutoff=6.0)[0]
+        assert _fmax(relaxed) < 0.5  # the loosened threshold used below
+        model.regressor_model.calls = 0
+        relax(model, [relaxed], fmax=0.5, steps=60, cutoff=6.0)
+        assert model.regressor_model.calls == 1
+
+    def test_one_force_evaluation_per_step(self, model):
+        steps = 5
+        model.regressor_model.calls = 0
+        relax(model, [_structure(displacement=0.4)], fmax=0.0, steps=steps, cutoff=6.0)
+        # 1 initial evaluation + 1 per step; a second call per step would mean
+        # the forces are being recomputed at unchanged positions.
+        assert model.regressor_model.calls == steps + 1
+
+
+class TestRelaxConstraints:
+    def test_fixed_atoms_do_not_move(self, model):
+        structure = _structure()
+        structure.set_constraint(FixAtoms(indices=[0, 1]))
+        before = structure.get_positions()
+        out = relax(model, [structure], fmax=0.01, steps=30, cutoff=6.0)[0]
+        assert np.allclose(out.get_positions()[:2], before[:2], atol=1e-5)
+        assert not np.allclose(out.get_positions()[2:], before[2:], atol=1e-5)
+
+    def test_constraints_are_carried_to_the_output(self, model):
+        structure = _structure()
+        structure.set_constraint(FixAtoms(indices=[0]))
+        out = relax(model, [structure], fmax=0.05, steps=5, cutoff=6.0)[0]
+        assert any(isinstance(c, FixAtoms) for c in out.constraints)
+
+
+class TestRelaxBatching:
+    def test_batched_matches_one_at_a_time(self, model):
+        structures = [_structure(seed=i) for i in range(3)]
+        batched = relax(model, structures, fmax=0.05, steps=30, cutoff=6.0)
+        singly = [
+            relax(model, [s], fmax=0.05, steps=30, cutoff=6.0)[0] for s in structures
+        ]
+        for b, s in zip(batched, singly):
+            assert np.allclose(b.get_positions(), s.get_positions(), atol=1e-4)
+
+    def test_converged_structure_is_left_alone(self, model):
+        """One structure converging must not perturb it while others relax."""
+        converged = relax(
+            model, [_structure(seed=1)], fmax=0.01, steps=80, cutoff=6.0
+        )[0]
+        displaced = _structure(displacement=0.4, seed=2)
+        out = relax(
+            model, [converged, displaced], fmax=0.05, steps=40, cutoff=6.0
+        )
+        assert np.allclose(
+            out[0].get_positions(), converged.get_positions(), atol=1e-5
+        )
+        assert not np.allclose(
+            out[1].get_positions(), displaced.get_positions(), atol=1e-5
+        )
+
+    def test_batch_size_does_not_change_the_result(self, model):
+        structures = [_structure(seed=i) for i in range(4)]
+        big = relax(model, structures, fmax=0.05, steps=20, batch_size=4, cutoff=6.0)
+        small = relax(model, structures, fmax=0.05, steps=20, batch_size=2, cutoff=6.0)
+        for a, b in zip(big, small):
+            assert np.allclose(a.get_positions(), b.get_positions(), atol=1e-4)
+
+
+class TestRelaxTrajectory:
+    def test_returns_a_trajectory_per_structure(self, model):
+        structures = [_structure(seed=i) for i in range(2)]
+        trajs = relax(
+            model, structures, fmax=0.05, steps=5, cutoff=6.0, trajectory=True
+        )
+        assert len(trajs) == 2
+        assert all(len(t) >= 2 for t in trajs)
+
+    def test_trajectory_starts_at_the_input_geometry(self, model):
+        structure = _structure()
+        traj = relax(
+            model, [structure], fmax=0.05, steps=5, cutoff=6.0, trajectory=True
+        )[0]
+        assert np.allclose(
+            traj[0].get_positions(), structure.get_positions(), atol=1e-4
+        )
+
+    def test_trajectory_ends_where_the_plain_call_ends(self, model):
+        structure = _structure()
+        traj = relax(
+            model, [structure], fmax=0.05, steps=20, cutoff=6.0, trajectory=True
+        )[0]
+        final = relax(model, [structure], fmax=0.05, steps=20, cutoff=6.0)[0]
+        assert np.allclose(traj[-1].get_positions(), final.get_positions(), atol=1e-5)


### PR DESCRIPTION
## The bug

The post-diffusion relaxation (`sample(max_extra_steps=...)`) **diverges on periodic structures** — the energy rises and the max force grows instead of falling.

`post_diffusion_relaxation_step` wraps positions back into the cell after every step ([guidance.py:437](https://github.com/nronne/agedi/blob/main/src/agedi/diffusion/guidance.py#L437)), so an atom crossing a cell face reappears a full lattice vector away. The step sizer reconstructs its displacement by differencing stored positions:

```python
s0 = pos - self.prev_pos      # picks up a ~10 Å jump on a wrap
y0 = self.prev_forces - forces  # ≈ 0, the structure barely moved
rho = 1.0 / torch.sum(y0 * s0)
```

That secant pair is garbage, `rho` blows up, and the two-loop recursion returns a direction unrelated to the forces — which `maxstep` then dutifully follows for a full 0.2 Å. Because `memory_size=100`, one wrap corrupts the rest of the run, and since `s`/`y` are whole-structure vectors, one atom wrecks the direction for all of them.

After the last diffusion step every position is wrapped into the cell, so with ~0.2 Å steps in a 10 Å cell each atom has roughly a 4% chance per periodic direction per step of crossing a face — with 20 mobile atoms it is essentially certain within the first few steps. Non-periodic systems are unaffected (`wrap_positions` returns early when `pbc.any()` is false), which is why the existing tests missed this: they all use clusters in a non-periodic box with zero-force mock regressors.

## The fix

Displacements reconstructed from stored positions now go through the minimum-image convention (`minimum_image()`), with the cell and `pbc` threaded down into the step sizers.

Measured on Cu₈ in a 10 Å periodic cell against **exact EMT forces**, 40 steps:

| | E start → end | fmax start → end |
|---|---|---|
| on boundary, before | 10.5288 → **15.3509** | 1.6937 → 2.2298 |
| on boundary, after | 10.5288 → **7.6045** | 1.6937 → 0.1399 |
| mid-cell control | 10.5288 → 7.6045 | 1.6937 → 0.1399 |
| `ase.optimize.LBFGS` | 10.5288 → 7.6045 | 1.6937 → 0.1398 |

Force-field guidance (`ff_guidance`) shares the same step sizer and is fixed by the same change.

## Two cleanups in the same loop

- **Forces were evaluated twice per step** — once inside `post_diffusion_relaxation_step` and again for the convergence check, at identical positions. The check's forces are now passed into the next step, halving the cost of relaxation.
- **Convergence was batch-wide**, so every structure kept stepping until the worst one in the batch converged. It is now tracked per structure, and converged structures stop being stepped.

## New: `relax()` / `agedi relax`

Exposes the same batched L-BFGS optimiser for structures the user supplies, with no diffusion sampling involved — the relaxation counterpart to `predict`.

```bash
agedi relax logs/agedi/version_0 structures.traj --fmax 0.05
```

```python
from agedi import load_diffusion, relax
relaxed = relax(diffusion, structures, fmax=0.05)
```

Each structure is optimised by its own L-BFGS instance and drops out as it converges; ASE `FixAtoms` constraints are honoured; `trajectory=True` / `--save_trajectory` returns every optimiser step.

## Tests

`tests/diffusion/test_relaxation.py` (16) and `tests/test_relax_api.py` (17). Four of the new tests fail against the pre-fix code and pass after:

- `test_history_contains_no_lattice_jump` — the mechanism, directly
- `test_energy_decreases`, `test_forces_decrease`, `test_matches_ase_lbfgs` — end-to-end on EMT

There is also a `test_a_wrap_actually_happens_in_this_fixture` guard so the history test cannot silently stop exercising the wrap. Full suite: 790 passed, 18 skipped.

## Not addressed here

Two things found while investigating, left for separate PRs:

- The confinement clamp in `post_diffusion_relaxation_step` can poison the history the same way (a clamped atom's displacement is ~0 while its force stays large, so `ys → 0`). ASE handles constraints by projecting forces rather than clamping positions after the step. Not measured.
- The `ffpc` terminal phase is a finite-temperature sampler, not a relaxation: at the default `--ffpc_temperature 1.0` (1 eV ≈ 11,600 K) it converges to ⟨U − U_min⟩ = (3N/2)·T, so it raises the energy. Its `langevin_md` default time step is also ~10× larger than the documented "1 fs" (ASE internal time units), and the overdamped path raises `IndexError` for `ConfinedCellPositions` models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)