### PR TITLE
Fix relax()/inpaint() crash on fully_connected=True models

### DIFF
--- a/src/agedi/api/inpainting.py
+++ b/src/agedi/api/inpainting.py
@@ -213,8 +213,15 @@ def inpaint(
         _as_bool_mask(freeze, len(a)) if freeze is not None else None
         for a in atoms_list
     ]
+    fully_connected = getattr(diffusion, "fully_connected", False)
     structures = [
-        AtomsGraph.from_atoms(a, cutoff=cutoff, initialize_mask=False, confinement=confinement)
+        AtomsGraph.from_atoms(
+            a,
+            cutoff=cutoff,
+            initialize_mask=False,
+            confinement=confinement,
+            fully_connected=fully_connected,
+        )
         for a in atoms_list
     ]
 

--- a/src/agedi/api/relaxation.py
+++ b/src/agedi/api/relaxation.py
@@ -17,14 +17,26 @@ from agedi.diffusion.guidance import (
 from ._common import resolve_cutoff
 
 
-def _graph_from_atoms(atoms: Atoms, cutoff: float) -> AtomsGraph:
+def _graph_from_atoms(
+    atoms: Atoms, cutoff: float, fully_connected: bool = False
+) -> AtomsGraph:
     """Build a graph from *atoms*, carrying ``FixAtoms`` over to the mask.
 
     Masked atoms have their predicted forces zeroed by the regressor and their
     positions restored on assignment, so the mask is what makes ASE's
     ``FixAtoms`` constraint take effect during relaxation.
+
+    ``fully_connected`` must match the model's own setting: it is stored on
+    the graph and read by :meth:`~agedi.data.AtomsGraph.update_graph`, which
+    is called every relaxation step. Leaving it unset on a fully-connected
+    model makes ``update_graph`` rebuild a cutoff-based neighbour list
+    instead, silently changing the physics and, as the per-graph edge count
+    drifts, eventually breaking ``Batch.to_data_list()`` (whose slicing
+    metadata is fixed at ``Batch.from_data_list()`` time).
     """
-    graph = AtomsGraph.from_atoms(atoms, cutoff=cutoff, initialize_mask=True)
+    graph = AtomsGraph.from_atoms(
+        atoms, cutoff=cutoff, initialize_mask=True, fully_connected=fully_connected
+    )
     for constraint in atoms.constraints:
         if isinstance(constraint, FixAtoms):
             graph.mask[constraint.index] = True
@@ -128,9 +140,13 @@ def relax(
         flat_structures = list(structures)
 
     cutoff = resolve_cutoff(diffusion, cutoff)
+    fully_connected = getattr(diffusion, "fully_connected", False)
     device = next(diffusion.parameters()).device
 
-    graphs = [_graph_from_atoms(atoms, cutoff) for atoms in flat_structures]
+    graphs = [
+        _graph_from_atoms(atoms, cutoff, fully_connected=fully_connected)
+        for atoms in flat_structures
+    ]
     n_structures = len(graphs)
 
     console = Console()

--- a/tests/test_relax_api.py
+++ b/tests/test_relax_api.py
@@ -192,6 +192,53 @@ class TestRelaxBatching:
             assert np.allclose(a.get_positions(), b.get_positions(), atol=1e-4)
 
 
+def _cramped_cluster(n, seed, spread=1.5):
+    """A cluster of *n* atoms crammed into a small sphere.
+
+    Deliberately starts with almost every pair inside a small cutoff, then
+    lets EMT forces push the atoms apart towards their equilibrium spacing —
+    so the cutoff-based neighbour count drops sharply over the relaxation,
+    which is what exposes the ``fully_connected`` regression below.
+    """
+    rng = np.random.default_rng(seed)
+    center = np.array([L / 2] * 3)
+    pos = center + rng.uniform(-spread / 2, spread / 2, size=(n, 3))
+    return Atoms("Cu" + str(n), positions=pos, cell=np.eye(3) * L, pbc=True)
+
+
+class TestRelaxFullyConnected:
+    def test_fully_connected_model_does_not_crash(self, model):
+        """Regression test: on a model trained with ``fully_connected=True``,
+        ``relax()`` must build its graphs with ``fully_connected=True`` too.
+
+        Otherwise ``AtomsGraph.update_graph()`` (called every step) silently
+        takes the cutoff-rebuild branch instead of the static fully-connected
+        one. As atoms move, per-graph edge counts drift away from what
+        ``Batch.from_data_list()`` recorded in ``_slice_dict``/``_inc_dict``,
+        and ``Batch.to_data_list()`` eventually slices ``edge_index`` with
+        stale offsets, raising e.g. "start (188) + length (240) exceeds
+        dimension size (342)". Confirmed to reproduce that crash with these
+        exact parameters when ``fully_connected`` is not threaded through
+        ``relax()``.
+        """
+        model.fully_connected = True
+        structures = [
+            _cramped_cluster(n, seed=i) for i, n in enumerate([8, 12, 16, 20])
+        ]
+
+        out = relax(
+            model,
+            structures,
+            fmax=0.0001,
+            steps=150,
+            cutoff=3.0,
+            batch_size=4,
+        )
+
+        assert len(out) == 4
+        assert all(isinstance(a, Atoms) for a in out)
+
+
 class TestRelaxTrajectory:
     def test_returns_a_trajectory_per_structure(self, model):
         structures = [_structure(seed=i) for i in range(2)]


### PR DESCRIPTION
## Summary
- `agedi.relax()` crashed on any `fully_connected=True` model as soon as a candidate needed more than 0 L-BFGS steps, with `RuntimeError: start (X) + length (Y) exceeds dimension size (Z)`.
- Root cause: `_graph_from_atoms()` in `relaxation.py` built every candidate graph via `AtomsGraph.from_atoms(..., initialize_mask=True)` without passing `fully_connected`, even when the model was created with `fully_connected=True`. `resolve_cutoff()` only resolves the cutoff, not this flag.
- Without `fully_connected` set on the graph, `AtomsGraph.update_graph()` (called every step) took the cutoff-based neighbor-rebuild branch instead of the static fully-connected one. That branch reassigns `batch.edge_index`/`shift_vectors` in place as atoms move, but never refreshes PyG's `Batch._slice_dict`/`_inc_dict` (fixed once at `Batch.from_data_list()` time). Once per-graph edge counts drift from their recorded values, `Batch.to_data_list()` slices `edge_index` with stale offsets and crashes.
- Fix: thread `fully_connected` through `relax()`, mirroring the existing pattern in `diffusion.py`'s `sample()` (`getattr(diffusion, "fully_connected", False)`, passed into graph construction). Applied the identical fix to `inpainting.py`'s initial `AtomsGraph.from_atoms()` call, which had the same gap.
- Not fixed (flagged only): a non-fully-connected model's `relax()` is still, in principle, vulnerable to the same slice-staleness class if the cutoff-based neighbor list legitimately changes edge count mid-relaxation — a separate, more invasive fix (keeping `Batch` slice metadata in sync with in-place `edge_index` mutation, or avoiding `to_data_list()` in favor of re-splitting by known per-graph atom counts).

## Test plan
- [x] Added `TestRelaxFullyConnected::test_fully_connected_model_does_not_crash` in `tests/test_relax_api.py`: crams clusters of different sizes (8/12/16/20 atoms) into a small sphere with a tight cutoff and lets EMT forces expand them during relaxation, which drops per-graph edge counts sharply. Verified this reproduces the exact reported error (`start (188) + length (240) exceeds dimension size (342)`) when the fix is reverted, and passes cleanly with it applied.
- [x] `pytest tests/test_relax_api.py tests/diffusion/test_relaxation.py tests/diffusion/samplers/test_inpaint.py` — 126 passed, 4 skipped (unrelated)
- [x] Full suite: `pytest tests/` — 1065 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)