### PR TITLE
Fix masked-atom time leak in multi-call samplers

### DIFF
--- a/src/agedi/diffusion/samplers/ffpc.py
+++ b/src/agedi/diffusion/samplers/ffpc.py
@@ -259,7 +259,9 @@ class ForcefieldCorrectorSampler(Sampler):
         self._capture_frame(batch)
 
         # Advance time to t_{i-1} for the corrector.
-        batch.time = (batch.time - dt).clamp(min=0.0)
+        batch.add_batch_attr(
+            "time", (batch.time - dt).clamp(min=0.0), type="node"
+        )
 
         # Lazily create corrector_dt tensor on the correct device/dtype.
         if (

--- a/src/agedi/diffusion/samplers/heun.py
+++ b/src/agedi/diffusion/samplers/heun.py
@@ -98,7 +98,9 @@ class HeunSampler(Sampler):
         batch.wrap_positions()
 
         # --- Step 3: Advance time to t-dt, rebuild graph for second score call ---
-        batch.time = (t_current - dt).clamp(min=0.0)
+        batch.add_batch_attr(
+            "time", (t_current - dt).clamp(min=0.0), type="node"
+        )
         self._check_finite(batch, "Heun SDE predictor step")
         batch.update_graph()
 
@@ -122,7 +124,7 @@ class HeunSampler(Sampler):
                 batch.pos = original_states["pos"]
             else:
                 batch[n.key] = original_states[n.key]
-        batch.time = t_current
+        batch.add_batch_attr("time", t_current, type="node")
 
         # --- Step 6: Stochastic EM step using averaged scores ---
         # noiser.denoise() reads batch[key] (= x_t) and batch[key+"_score"]

--- a/src/agedi/diffusion/samplers/ode.py
+++ b/src/agedi/diffusion/samplers/ode.py
@@ -229,7 +229,9 @@ class HeunODESampler(Sampler):
         batch.wrap_positions()
 
         # --- Step 3: Advance time to t-dt, rebuild graph ---
-        batch.time = (t_current - dt).clamp(min=0.0)
+        batch.add_batch_attr(
+            "time", (t_current - dt).clamp(min=0.0), type="node"
+        )
         self._check_finite(batch, "Heun ODE predictor step")
         batch.update_graph()
 
@@ -252,7 +254,7 @@ class HeunODESampler(Sampler):
                 batch.pos = original_states["pos"]
             else:
                 batch[n.key] = original_states[n.key]
-        batch.time = t_current
+        batch.add_batch_attr("time", t_current, type="node")
 
         # --- Step 6: ODE corrector with averaged scores ---
         for noiser in reversed(sde_noisers):

--- a/src/agedi/diffusion/samplers/pc.py
+++ b/src/agedi/diffusion/samplers/pc.py
@@ -86,7 +86,9 @@ class PredictorCorrectorSampler(Sampler):
         self._capture_frame(batch)
 
         # Advance time to t_{i-1} for the corrector.
-        batch.time = (batch.time - dt).clamp(min=0.0)
+        batch.add_batch_attr(
+            "time", (batch.time - dt).clamp(min=0.0), type="node"
+        )
 
         # Lazily create corrector_dt tensor on the correct device/dtype.
         if (

--- a/tests/diffusion/samplers/test_samplers.py
+++ b/tests/diffusion/samplers/test_samplers.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 from agedi.data import AtomsGraph
+from agedi.diffusion.noisers import CellPositions
 from agedi.diffusion.samplers import (
     EulerMaruyamaSampler,
     ForcefieldCorrectorSampler,
@@ -1188,3 +1189,121 @@ class TestTerminalConfinement:
         # -ceiling would make every terminal frame sit exactly at z_max.
         at_wall = sum(1 for z in terminal if abs(z - self.CONF[1]) < 1e-4)
         assert at_wall < len(terminal), "every terminal frame is pinned at the wall"
+
+
+# ---------------------------------------------------------------------------
+# Masked-atom time consistency (regression test)
+# ---------------------------------------------------------------------------
+
+
+def _make_time_recording_score_fn(record):
+    """Return a score_fn stub that logs every ``batch.time`` it is called with."""
+
+    def score_fn(batch):
+        record.append(batch.time.clone())
+        batch["pos_score"] = torch.zeros_like(batch.pos)
+        return batch
+
+    return score_fn
+
+
+def _make_zero_regressor():
+    def regressor_fn(batch):
+        batch["forces_prediction"] = torch.zeros_like(batch.pos)
+        return batch
+
+    return regressor_fn
+
+
+def _prep_masked_batch(batch, t_val, dtype=torch.float):
+    """Set a uniform starting time and build the graph.
+
+    Mirrors ``Diffusion._sample_batch``'s own main loop, which writes time via
+    ``add_batch_attr`` directly rather than the ``.time`` setter, so every atom
+    (masked or not) starts at the same global time.
+    """
+    t = torch.tensor(t_val, dtype=dtype)
+    batch.add_batch_attr("time", t.repeat(batch.x.shape[0], 1), type="node")
+    batch.update_graph()
+    return batch
+
+
+@pytest.mark.parametrize("batch", ["surface"], indirect=True)
+class TestMaskedAtomTimeConsistency:
+    """A masked atom must see the same intermediate diffusion time as every
+    unmasked atom at every score call within a single sampler step.
+
+    Regression test for a bug where samplers advanced ``batch.time`` mid-step
+    via the ``.time`` property setter, which zeroes masked atoms' time instead
+    of giving them the real global time (unlike the main sampling loop, which
+    writes time directly via ``add_batch_attr``).
+    """
+
+    dt = torch.tensor(0.1)
+    t_val = 0.8
+
+    def _assert_uniform_and_correct(self, times, expected_values):
+        assert len(times) == len(expected_values)
+        for t, expected in zip(times, expected_values):
+            assert t.min() == t.max(), (
+                f"batch.time is not uniform across atoms: {t.unique()}"
+            )
+            assert torch.allclose(t, torch.full_like(t, expected)), (
+                f"expected time {expected}, got {t.unique()}"
+            )
+
+    def test_pc_corrector_time_is_uniform(self, batch):
+        batch = _prep_masked_batch(batch, self.t_val)
+        record = []
+        sampler = PredictorCorrectorSampler(
+            _make_time_recording_score_fn(record),
+            [CellPositions()],
+            corrector_steps=1,
+        )
+        sampler.step(batch, self.dt, last=False)
+        self._assert_uniform_and_correct(
+            record, [self.t_val, self.t_val - self.dt.item()]
+        )
+
+    def test_heun_second_score_call_time_is_uniform(self, batch):
+        batch = _prep_masked_batch(batch, self.t_val)
+        record = []
+        sampler = HeunSampler(
+            _make_time_recording_score_fn(record),
+            [CellPositions()],
+        )
+        sampler.step(batch, self.dt, last=False)
+        self._assert_uniform_and_correct(
+            record, [self.t_val, self.t_val - self.dt.item()]
+        )
+        # After the step, batch.time must be restored to t_current, not 0.
+        assert batch.time.min() == batch.time.max() == self.t_val
+
+    def test_ffpc_corrector_time_is_uniform(self, batch):
+        batch = _prep_masked_batch(batch, self.t_val)
+        record = []
+        sampler = ForcefieldCorrectorSampler(
+            _make_time_recording_score_fn(record),
+            [CellPositions()],
+            regressor_fn=_make_zero_regressor(),
+            corrector_steps=1,
+            temperature=0.5,
+        )
+        sampler.step(batch, self.dt, last=False)
+        self._assert_uniform_and_correct(
+            record, [self.t_val, self.t_val - self.dt.item()]
+        )
+
+    def test_heun_ode_second_score_call_time_is_uniform(self, batch):
+        batch = _prep_masked_batch(batch, self.t_val)
+        record = []
+        sampler = HeunODESampler(
+            _make_time_recording_score_fn(record),
+            [CellPositions()],
+        )
+        sampler.step(batch, self.dt, last=False)
+        self._assert_uniform_and_correct(
+            record, [self.t_val, self.t_val - self.dt.item()]
+        )
+        # After the step, batch.time must be restored to t_current, not 0.
+        assert batch.time.min() == batch.time.max() == self.t_val


### PR DESCRIPTION
## Summary

- `PredictorCorrectorSampler`, `HeunSampler`, `ForcefieldCorrectorSampler`, and `HeunODESampler` advance `batch.time` mid-step (for a corrector pass or a second score evaluation at `t - dt`) via the `.time` property setter, which forces every masked atom's time to `0.0` via `apply_mask` instead of the real intermediate time the rest of the batch sees.
- For a message-passing backbone (PaiNN/EGNN), `h` propagates across masked↔unmasked edges, so a masked neighbor's wrong `t=0` time-embedding can leak into an unmasked atom's computed score — a correctness risk for surface/confined systems using `MaskFixed` / `ConfinedCellPositions`, during the second/corrector score call of these four samplers specifically.
- Fix: replace all 6 `batch.time = <expr>` assignments (pc.py, heun.py ×2, ffpc.py, ode.py ×2) with `batch.add_batch_attr("time", <expr>, type="node")`, matching the pattern `Diffusion._sample_batch`'s own main loop already uses. The `.time` setter and `apply_mask` themselves are untouched — other call sites may rely on that existing masking behavior.

## Test plan

- [x] Added `TestMaskedAtomTimeConsistency` in `tests/diffusion/samplers/test_samplers.py`: uses the `surface` parametrization of the `batch` fixture (which sets `mask[:9] = True`) with a stub `score_fn` recording every `batch.time` it's called with, and asserts `batch.time` is uniform across all atoms at every score call for all four affected samplers.
- [x] Verified the regression test actually catches the bug: temporarily reverted the `heun.py` fix and reran — failed with `tensor([0.0000, 0.7000])`, the exact masked-atom leak described above.
- [x] Full suite: `773 passed`, 6 pre-existing failures in `test_diffusion.py::test_backward` unrelated to this change (plain `loss.backward()`, failing on `RuntimeError: Resource temporarily unavailable` — a sandbox resource-exhaustion issue, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)